### PR TITLE
changed build definitions such that we can publish to sonatype.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ All code is available to you under the Apache license, version 2, available at h
 
 Copyright, University of Basel, 2016.
 
+## Deploy to sonatype
+
+Unfortunately, we cannot directly publish to sonatype using sbt. Instead, we need to do a publish, 
+and then upload the files manually. To add insult to insjury, we currently also need to sign the files manually. 
+Do the following:
+
+* sbt publish
+* navigate to the tmp directly, and there in the subfolder where the files were published
+* sign all the files using: for f in *.jar *.pom; do gpg2   -ab  $f ; done
+* directly from this directory, create a zip file
+* upload them manually to https://oss.sonatype.org/#stagingRepositories
+

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,28 @@ organization in ThisBuild := productPackage.mkString(".")
 
 version in ThisBuild := productVersion
 
-javacOptions in ThisBuild ++= Seq("-source", "1.6", "-target", "1.6")
+javacOptions in ThisBuild ++= Seq("-source", "1.8", "-target", "1.8")
 
-scalacOptions in ThisBuild ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.6")
+javacOptions in (ThisBuild, doc) := Seq("-source", "1.8")
+
+scalacOptions in ThisBuild ++= Seq("-encoding", "UTF-8", "-Xlint", "-deprecation", "-unchecked", "-feature", "-target:jvm-1.8")
 
 publishTo in ThisBuild := Some(Resolver.file("file",  new File( publishPrefix )) )
 
 crossPaths in ThisBuild := false
 
+
+homepage in ThisBuild := Some(url("https://scalismo.org"))
+licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
+scmInfo in ThisBuild := Some(ScmInfo(url("https://github.com/unibas-gravis/scalismo-native"), "git@github.com:unibas-gravis/scalismo-native.git"))
+developers in ThisBuild := List(Developer("marcelluethi", "marcelluethi", "marcel.luethi@unibas.ch", url("https://github.com/marcelluethi")))
+publishMavenStyle := true
+publishTo in ThisBuild := Some(
+      if (isSnapshot.value)
+        Opts.resolver.sonatypeSnapshots
+      else
+        Opts.resolver.sonatypeStaging
+    )
 
 
 // the root project itself does not publish anything, but depends on the publish[-local] tasks.

--- a/build.sbt
+++ b/build.sbt
@@ -22,13 +22,24 @@ licenses in ThisBuild += ("Apache-2.0", url("http://www.apache.org/licenses/LICE
 scmInfo in ThisBuild := Some(ScmInfo(url("https://github.com/unibas-gravis/scalismo-native"), "git@github.com:unibas-gravis/scalismo-native.git"))
 developers in ThisBuild := List(Developer("marcelluethi", "marcelluethi", "marcel.luethi@unibas.ch", url("https://github.com/marcelluethi")))
 publishMavenStyle := true
-publishTo in ThisBuild := Some(
-      if (isSnapshot.value)
-        Opts.resolver.sonatypeSnapshots
-      else
-        Opts.resolver.sonatypeStaging
-    )
 
+/*
+ Eventually we want to publish to sonatype. However, as the files in the
+ build need fixup locally, we cannot directly publish. Rather we publish in
+ a tmp directory and copy the resulting release files manually onto sonatype.
+ This is justified as we don't release often.
+*/
+
+// This is what we would like to do
+//publishTo in ThisBuild := Some(
+//      if (isSnapshot.value)
+//        Opts.resolver.sonatypeSnapshots
+//      else
+//        Opts.resolver.sonatypeStaging
+//    )
+
+// This is what we do instead
+publishTo := Some(MavenCache("local-maven", new File( publishPrefix )))
 
 // the root project itself does not publish anything, but depends on the publish[-local] tasks.
 // Well, except that for the implementation, it also needs to be "fixed up".
@@ -36,9 +47,23 @@ publishTo in ThisBuild := Some(
 
 publishLocal := {}
 
-publishLocal <<= publishLocal dependsOn (publishLocalFixup in impl_all, publishLocalFixup in impl_linux64, publishLocalFixup in impl_mac64, publishLocalFixup in impl_win64, publishLocalFixup in impl_win32, publishLocalFixup in impl_win)
+publishLocal <<= publishLocal dependsOn (
+  publishLocalFixup in impl_all,
+  publishLocalFixup in impl_linux64,
+  publishLocalFixup in impl_mac64,
+  publishLocalFixup in impl_win64,
+  publishLocalFixup in impl_win32,
+  publishLocalFixup in impl_win
+)
 
 publish := {}
 
-publish <<= publish dependsOn (publishFixup in impl_all, publishFixup in impl_linux64, publishFixup in impl_mac64, publishFixup in impl_win64, publishFixup in impl_win32, publishFixup in impl_win)
+publish <<= publish dependsOn (
+  publishFixup in impl_all,
+  publishFixup in impl_linux64,
+  publishFixup in impl_mac64,
+  publishFixup in impl_win64,
+  publishFixup in impl_win32,
+  publishFixup in impl_win
+)
 

--- a/implementation/build.sbt
+++ b/implementation/build.sbt
@@ -16,6 +16,7 @@ publishFixup <<= (baseDirectory, name, fixupExclude) map { (base, productName, e
     productName,
     excludes
   ).!
+
 }
 
 publishLocalFixup <<= (baseDirectory, name, fixupExclude) map { (base, productName, exclude) =>
@@ -37,5 +38,5 @@ publishFixup <<= publishFixup dependsOn(publishFixup in stub, publish)
 // that's not strictly required for sbt proper, but it helps IntelliJ Idea.
 unmanagedBase := (unmanagedBase in stub).value
 
-publishArtifact in(Compile, packageDoc) := false
+publishArtifact in(Compile, packageDoc) := true
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,7 +47,7 @@ object Build extends sbt.Build {
 
   lazy val productPackage = Seq("ch", "unibas", "cs", "gravis")
 
-  lazy val publishPrefix = "/export/contrib/statismo/repo/public"
+  lazy val publishPrefix = s"${System.getProperty("java.io.tmpdir")}"
   lazy val publishLocalPrefix = s"${System.getProperty("user.home")}/.ivy2/local"
 
   // these task and settings keys are needed for the implementation project

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,7 @@ object Build extends sbt.Build {
   // stub/src/main/java/scalismo/support/nativelibs/NativeLibraryBundles.java
   // implementation/src/main/java/scalismo/support/nativelibs/NativeLibraryBundlesImplementation.java
   //
-  lazy val productVersion = "4.0.0"
+  lazy val productVersion = "4.0.1"
 
 
   lazy val productPackage = Seq("ch", "unibas", "cs", "gravis")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,9 @@
+resolvers += Resolver.url("bintray-sbt-plugin-releases", url("https://dl.bintray.com/banno/oss"))(
+  Resolver.ivyStylePatterns
+)
+
+resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
+
+
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/stub/build.sbt
+++ b/stub/build.sbt
@@ -3,7 +3,7 @@
 
 name := "scalismo-native-stub"
 
-publishArtifact in(Compile, packageDoc) := false
+publishArtifact in(Compile, packageDoc) := true
 
 publishFixup <<= (baseDirectory, unmanagedBase in Compile, name) map { (base, lib, productName) =>
   val topDir = s"$publishPrefix/${productPackage.mkString("/")}"


### PR DESCRIPTION
As bintray sunsetting its services, we will now publish to sonatype (maven central).
This PR makes the necessary changes to the build definitions. Note that we also publish the api doc, as in conrast to bintray, we cannot publish a package without api doc. 